### PR TITLE
Add the host as a configuration option in connection

### DIFF
--- a/src/Context/Initializer/WordPressContextInitializer.php
+++ b/src/Context/Initializer/WordPressContextInitializer.php
@@ -100,11 +100,13 @@ class WordPressContextInitializer implements ContextInitializer
                 str_replace(array(
                     "'DB_NAME', 'database_name_here'",
                     "'DB_USER', 'username_here'",
-                    "'DB_PASSWORD', 'password_here'"
+                    "'DB_PASSWORD', 'password_here'",
+                    "'DB_HOST', 'localhost'",
                 ), array(
                     sprintf("'DB_NAME', '%s'", $this->wordpressParams['connection']['db']),
                     sprintf("'DB_USER', '%s'", $this->wordpressParams['connection']['username']),
                     sprintf("'DB_PASSWORD', '%s'", $this->wordpressParams['connection']['password']),
+                    sprintf("'DB_HOST', '%s'", $this->wordpressParams['connection']['host']),
                 ), $file->getContents());
             $fs->dumpFile($file->getPath() . '/wp-config.php', $configContent);
         }
@@ -129,7 +131,7 @@ class WordPressContextInitializer implements ContextInitializer
         if ($this->wordpressParams['flush_database']) {
             $connection = $this->wordpressParams['connection'];
             $mysqli = new \Mysqli(
-                'localhost',
+                $connection['host'],
                 $connection['username'],
                 $connection['password'],
                 $connection['db']

--- a/src/ServiceContainer/WordPressExtension.php
+++ b/src/ServiceContainer/WordPressExtension.php
@@ -79,6 +79,9 @@ class WordPressExtension implements ExtensionInterface
                         ->scalarNode('password')
                             ->defaultValue('')
                         ->end()
+                        ->scalarNode('host')
+                            ->defaultValue('localhost')
+                        ->end()
                     ->end()
                 ->end()
             ->end();


### PR DESCRIPTION
Sometimes I need to use something besides locahost for the mysql address (e.g. when using docker containers to create disposable databases). This would add `host` as a connection option and open up that possibility.
