### PR TITLE
Use third argument of symlink method

### DIFF
--- a/src/Context/Initializer/WordPressContextInitializer.php
+++ b/src/Context/Initializer/WordPressContextInitializer.php
@@ -116,7 +116,7 @@ class WordPressContextInitializer implements ContextInitializer
                 $from = $this->basePath . DIRECTORY_SEPARATOR . $from;
             }
             if ($fs->exists($this->wordpressParams['symlink']['from'])) {
-                $fs->symlink($from, $this->wordpressParams['symlink']['to']);
+                $fs->symlink($from, $this->wordpressParams['symlink']['to'], true);
             }
         }
     }


### PR DESCRIPTION
This instructs the symlink function to use copy instead of symlink if on a filesystem that doesn't support symlinks.
